### PR TITLE
Added support for --component option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ bower_components/
 
 # Dist folder
 dist/
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,2 @@
+2016-07-18
+- added feature to create root component along with container (see #2)

--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@
 
 This is a sub generator for creating _container_ components with
 [Generator React Webpack v4](https://github.com/newtriks/generator-react-webpack).
+
+To inject the sub generator into Generator React Webpack, see the experimental [generator-subgenext](https://github.com/sthzg/generator-subgenext).
+
+
+## What it does
+
+```sh
+react-webpack:container foo
+# Creates FooContainer.js
+
+react-webpack:container foo --component
+# Creates Foo.js and FooContainer.js. FooContainer.js renders <Foo />
+```

--- a/generators/container/containerTest.js
+++ b/generators/container/containerTest.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const ejs                         = require('ejs');
+const lodash                      = require('lodash');
+const through                     = require('through2');
+
+
+/**
+ * Renders our modified template to create a container test.
+ *
+ * See `generators/container/templates/ContainerTest.js.ejs` for the template.
+ *
+ * @param {string} cntName
+ * @param {string} cmpName
+ * @param {string} testTpl
+ */
+module.exports = function (cntName, cmpName, testTpl) {
+  return through.obj(function (file, encoding, callback) {
+    const template = ejs.compile(testTpl);
+
+    file.contents = new Buffer(template({ cntName, cmpName }));
+
+    callback(null, file);
+  });
+};

--- a/generators/container/index.js
+++ b/generators/container/index.js
@@ -7,12 +7,9 @@
 const acorn                       = require('acorn-jsx');
 const escodegen                   = require('escodegen-wallaby');
 const esformatter                 = require('esformatter');
-const esDefaultOpts               = require('esformatter/lib/preset/default.json');
 const fs                          = require('fs');
 const generators                  = require('yeoman-generator');
 const gulpfilter                  = require('gulp-filter');
-const gulpif                      = require('gulp-if');
-const jp                          = require('jsonpath');
 const lodash                      = require('lodash');
 const path                        = require('path');
 
@@ -56,6 +53,11 @@ class ContainerGenerator extends generators.Base {
     this.composeWith('react-webpack:component', {
       options: Object.assign({}, this.options, { nostyle: true }),
       args: this.args
+    });
+
+    this.composeWith('react-webpack:component', {
+      options: Object.assign({}, this.options),
+      args: [this.cmpName]
     });
 
   }

--- a/generators/container/index.js
+++ b/generators/container/index.js
@@ -1,15 +1,33 @@
+/**
+ * @module Container
+ */
+
 'use strict';
 
+const acorn                       = require('acorn-jsx');
+const escodegen                   = require('escodegen-wallaby');
+const esformatter                 = require('esformatter');
+const esDefaultOpts               = require('esformatter/lib/preset/default.json');
+const fs                          = require('fs');
 const generators                  = require('yeoman-generator');
+const gulpfilter                  = require('gulp-filter');
+const gulpif                      = require('gulp-if');
+const jp                          = require('jsonpath');
+const lodash                      = require('lodash');
+const path                        = require('path');
+
+const transformCnt                = require('./transform');
+
+esformatter.register(require('esformatter-jsx'));
 
 
-class Generator extends generators.Base {
+class ContainerGenerator extends generators.Base {
 
   constructor(...args) {
     super(...args);
   }
 
-  _hasCntPostfix(cntName) {
+  static _hasCntPostfix(cntName) {
     const regex = new RegExp('[c|C]ontainer$');
     return regex.exec(cntName) !== null;
   }
@@ -22,19 +40,38 @@ class Generator extends generators.Base {
         required: true
       });
 
-    if (!this._hasCntPostfix(this.cntName)) {
+    this.option(
+      'component', {
+        desc: 'Create a Root Component and render it from the Container'
+      }
+    );
+
+    if (!ContainerGenerator._hasCntPostfix(this.cntName)) {
       this.cntName = this.cntName + 'Container';
     }
+
+    this.cntName = lodash.upperFirst(this.cntName);
+    this.cmpName = this.cntName.replace(/(c|C)ontainer$/, '');
 
     this.composeWith('react-webpack:component', {
       options: Object.assign({}, this.options, { nostyle: true }),
       args: this.args
     });
+
   }
 
-  writing(foo) {
+  writing() {
+
+    if (this.options.component) {
+      const cntFilter = gulpfilter(['**/*Container.js'], { restore: true });
+      this.registerTransformStream([
+        cntFilter,
+        transformCnt(this.cntName, this.cmpName),
+        cntFilter.restore
+      ]);
+    }
   }
 
 }
 
-module.exports = Generator;
+module.exports = ContainerGenerator;

--- a/generators/container/index.js
+++ b/generators/container/index.js
@@ -13,9 +13,8 @@ const gulpfilter                  = require('gulp-filter');
 const lodash                      = require('lodash');
 const path                        = require('path');
 
+const containerTest               = require('./containerTest');
 const transformCnt                = require('./transform');
-
-esformatter.register(require('esformatter-jsx'));
 
 
 class ContainerGenerator extends generators.Base {
@@ -63,6 +62,14 @@ class ContainerGenerator extends generators.Base {
   }
 
   writing() {
+
+    // Swap the test file  for the container with our customized template
+    const tstFilter = gulpfilter(['**/*ContainerTest.js'], { restore: true });
+    this.registerTransformStream([
+      tstFilter,
+      containerTest(this.cntName, this.cmpName, this.fs.read(this.templatePath('ContainerTest.js.ejs'))),
+      tstFilter.restore
+    ]);
 
     if (this.options.component) {
       const cntFilter = gulpfilter(['**/*Container.js'], { restore: true });

--- a/generators/container/templates/ContainerTest.js.ejs
+++ b/generators/container/templates/ContainerTest.js.ejs
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import FoobarContainer from 'components//<%= cntName %>.js';
+
+describe('<<%= cntName %> />', () => {
+
+  let component;
+  beforeEach(() => {
+    component = shallow(<<%= cntName %> />);
+  });
+
+  describe('when rendering the component', () => {
+
+    it('should render <<%= cmpName %> />', () => {
+      expect(component.name()).to.equal('<%= cmpName %>');
+    });
+  });
+});

--- a/generators/container/transform.js
+++ b/generators/container/transform.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const acorn                       = require('acorn-jsx');
+const escodegen                   = require('escodegen-wallaby');
+const esformatter                 = require('esformatter');
+const esDefaultOpts               = require('esformatter/lib/preset/default.json');
+const fs                          = require('fs');
+const jp                          = require('jsonpath');
+const lodash                      = require('lodash');
+const through                     = require('through2');
+
+
+function buildCmpImportNode(cmpName) {
+  return acorn.parse(`import ${cmpName} from './${cmpName}';`, { sourceType: 'module' }).body[0];
+}
+
+function buildCmpRender(cmpName) {
+  return acorn.parse(`<${cmpName} />`, { plugins: { jsx: true } });
+}
+
+
+module.exports = function (cntName, cmpName) {
+  return through.obj(function (file, encoding, callback) {
+
+    // Parse the content to an AST
+    let cntPar = acorn.parse(file.contents.toString(), {
+      sourceType: 'module',
+      plugins: {
+        jsx: true
+      }
+    });
+
+    // Add an import statement for the root component
+    cntPar.body
+      .splice(
+        lodash.findLastIndex(cntPar.body, n => n.type === 'ImportDeclaration') + 1, 0,
+        buildCmpImportNode(cmpName)
+      );
+
+    // Modify the Container's render output to render the root component
+    jp.value(cntPar, '$..*[?(@.type=="JSXElement")]', buildCmpRender(cmpName).body[0].expression);
+
+    // Get the AST-code as Javascript again
+    const jsFromAst = escodegen.generate(cntPar, { format: { indent: { style: '  ' } } });
+
+    // Pretty print the generated code
+    // TODO reuse some existing gulp plugin for that or at least provide a separate transform step for it
+    const styleOpts = Object.assign({}, esDefaultOpts, {
+      "lineBreak": {
+        "before": {
+          "ClassDeclaration": 2,
+          "EndOfFile": 1,
+          "ExportAllDeclaration": ">=2",
+          "ExportDefaultDeclaration": ">=2",
+          "ExportNamedDeclaration": ">=2"
+        },
+        "after": {
+          "ClassClosingBrace": 2
+        }
+      },
+      "jsx": {
+        "formatJSX": true,
+        "attrsOnSameLineAsTag": false,
+        "maxAttrsOnTag": 3,
+        "firstAttributeOnSameLine": true,
+        "formatJSXExpressions": true,
+        "JSXExpressionsSingleLine": true,
+        "alignWithFirstAttribute": false,
+        "spaceInJSXExpressionContainers": " ",
+        "removeSpaceBeforeClosingJSX": false,
+        "htmlOptions": {}
+      }
+    });
+    const formatted = esformatter.format('\'use strict\';\n\n' + jsFromAst, styleOpts);
+
+    file.contents = new Buffer(formatted);
+
+    callback(null, file);
+  });
+};

--- a/generators/container/transform.js
+++ b/generators/container/transform.js
@@ -28,6 +28,12 @@ function buildCmpRender(cmpName) {
 }
 
 
+/**
+ * Transforms the container component that is generated from the original generator to represent a container.
+ *
+ * @param {string} cntName
+ * @param {string} cmpName
+ */
 module.exports = function (cntName, cmpName) {
   return through.obj(function (file, encoding, callback) {
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,19 @@
   ],
   "homepage": "https://github.com/sthzg/contrib-subgen-react-webpack-container#readme",
   "devDependencies": {
+    "acorn-jsx": "^3.0.1",
     "babel-eslint": "^6.1.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.9",
+    "escodegen": "^1.8.0",
+    "escodegen-wallaby": "^1.6.7",
     "eslint": "^3.0.1",
     "eslint-config-airbnb": "^9.0.1",
     "eslint-plugin-import": "^1.10.2",
     "fs-extra": "^0.30.0",
     "generator-react-webpack": "^4.0.1-1",
     "istanbul": "^0.4.4",
+    "lodash": "^4.13.1",
     "mocha": "^2.5.3",
     "mocha-lcov-reporter": "^1.2.0",
     "yeoman-assert": "^2.2.1",
@@ -44,5 +48,13 @@
     "release:major": "npm version major && npm publish && git push --follow-tags",
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags"
+  },
+  "dependencies": {
+    "esformatter": "^0.9.5",
+    "esformatter-jsx": "^7.0.1",
+    "gulp-filter": "^4.0.0",
+    "gulp-if": "^2.0.1",
+    "jsonpath": "^0.2.6",
+    "through2": "^2.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "release:patch": "npm version patch && npm publish && git push --follow-tags"
   },
   "dependencies": {
+    "ejs": "^2.4.2",
     "esformatter": "^0.9.5",
     "esformatter-jsx": "^7.0.1",
     "gulp-filter": "^4.0.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "globals": {
+    "expect": true
+  }
+}

--- a/test/generators/container/genContainerTest.js
+++ b/test/generators/container/genContainerTest.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const before                      = require('mocha').before;
-const describe                    = require('mocha').describe;
-const it                          = require('mocha').it;
-
 const assert                      = require('yeoman-assert');
 const chai                        = require('chai').assert;
 const fs                          = require('fs-extra');


### PR DESCRIPTION
Running `yo react-webpack:container foo --component` will create `<Foo />` and `<FooContainer />` and modifies `<FooContainer />`'s render method to render `<Foo />`.

Closes #2 
